### PR TITLE
merge request and response actions; support multiple actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,15 +454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "nix"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,7 +933,6 @@ dependencies = [
  "hyper",
  "iptables",
  "libc",
- "multimap",
  "paw",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ humantime-serde = "1.0"
 hyper = {version = "0.14.4", features = ["runtime", "client", "server", "http1", "http2"]}
 iptables = "0.4"
 libc = {version = "0.2.81", features = ["std"]}
-multimap = "0.8"
 paw = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 serde_derive = "1.0.123"

--- a/config-examples/abort_by_path.yaml
+++ b/config-examples/abort_by_path.yaml
@@ -1,7 +1,8 @@
 proxy_ports: [80, 8080, 30086] # cannot be empty
 rules:
-  request:
-  - selector:
+  - target: Request
+    selector:
       path: /src # match all path starts with "/example"
       method: GET
-    action: abort
+    actions:
+      abort: true

--- a/config-examples/json_example.json
+++ b/config-examples/json_example.json
@@ -25,10 +25,7 @@
       "selector": {
         "path": "/example",
         "method": "GET",
-        "code": 404,
-        "response_headers": {
-          "Server": "nginx"
-        }
+        "code": 404
       },
       "actions": {
         "abort": true

--- a/config-examples/json_example.json
+++ b/config-examples/json_example.json
@@ -1,33 +1,38 @@
 {
   "listen_port": 58080,
-  "proxy_ports": [80, 443, 8080],
+  "proxy_ports": [80, 8080, 30086],
   "proxy_mark": 1,
   "ignore_mark": 255,
-  "rules": {
-    "request": [
-      {
-        "selector": {
-          "path": "/example",
-          "method": "GET"
-        },
-        "action": {
-          "delay": "10s"
+  "rules": [
+    {
+      "target": "Request",
+      "selector": {
+        "path": "/example",
+        "method": "GET"
+      },
+      "actions": {
+        "delay": "10s",
+        "append": {
+          "queries": [
+            ["foo", "bar"],
+            ["foo", "other"]
+          ]
         }
       }
-    ],
-    "response": [
-      {
-        "selector": {
-          "path": "/example",
-          "method": "GET",
-          "code": 404,
-          "response_headers": {
-            "Server": "nginx"
-          }
-        },
-        "action": "delay"
+    },
+    {
+      "target": "Response",
+      "selector": {
+        "path": "/example",
+        "method": "GET",
+        "code": 404,
+        "response_headers": {
+          "Server": "nginx"
+        }
+      },
+      "actions": {
+        "abort": true
       }
-    ]
-  }
+    }
+  ]
 }
-

--- a/config-examples/yaml_example.yaml
+++ b/config-examples/yaml_example.yaml
@@ -20,7 +20,5 @@ rules:
       path: /example
       method: GET
       code: 404
-      response_headers:
-        Server: nginx
     actions:
       abort: true

--- a/config-examples/yaml_example.yaml
+++ b/config-examples/yaml_example.yaml
@@ -3,20 +3,24 @@ proxy_ports: [80, 443, 8080] # cannot be empty
 proxy_mark: 1 # optional
 ignore_mark: 255 # optional
 rules:
-  request:
-  - selector:
+  - target: Request
+    selector:
       port: 8080
       path: /example # match all path starts with "/example"
       method: GET
-    action:
+    actions:
       delay: 10s 
-  response:
-  - selector:
+      append:
+        queries:
+        - [foo, bar]
+        - [foo, other]
+  - target: Response
+    selector:
       port: 80
       path: /example
       method: GET
       code: 404
       response_headers:
         Server: nginx
-    action: abort
-
+    actions:
+      abort: true

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -60,7 +60,7 @@ mod test {
                         port: None,
                         path: Some("/rs-tproxy".to_string()),
                         method: Some("GET".to_string()),
-                        headers: Some(
+                        request_headers: Some(
                             [("aname", "avalue")]
                                 .iter()
                                 .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -82,7 +82,7 @@ mod test {
                         port: None,
                         path: Some("/rs-tproxy".to_string()),
                         method: Some("GET".to_string()),
-                        headers: Some(
+                        request_headers: Some(
                             [("aname", "avalue")]
                                 .iter()
                                 .map(|(k, v)| (k.to_string(), v.to_string()))

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -39,7 +39,7 @@ pub struct RawSelector {
     pub path: Option<String>,
     pub method: Option<String>,
     pub code: Option<u16>,
-    pub headers: Option<HashMap<String, String>>,
+    pub request_headers: Option<HashMap<String, String>>,
     pub response_headers: Option<HashMap<String, String>>,
 }
 
@@ -148,8 +148,8 @@ impl TryFrom<RawSelector> for Selector {
                 .as_ref()
                 .map(|method| method.parse())
                 .transpose()?,
-            headers: raw
-                .headers
+            request_headers: raw
+                .request_headers
                 .as_ref()
                 .map(|headers| -> Result<_, Self::Error> {
                     let mut map = HeaderMap::new();
@@ -213,7 +213,7 @@ impl TryFrom<RawReplaceAction> for ReplaceAction {
 
     fn try_from(raw: RawReplaceAction) -> Result<Self, Self::Error> {
         Ok(Self {
-            path: raw.path.as_ref().map(|path| path.parse()).transpose()?,
+            path: raw.path,
             method: raw
                 .method
                 .as_ref()

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -27,8 +27,8 @@ pub struct Selector {
     pub port: Option<u16>,
     pub path: Option<PathAndQuery>,
     pub method: Option<Method>,
-    pub headers: Option<HeaderMap>,
     pub code: Option<StatusCode>,
+    pub request_headers: Option<HeaderMap>,
     pub response_headers: Option<HeaderMap>,
 }
 
@@ -63,7 +63,7 @@ pub fn select_request(port: u16, request: &Request<Body>, selector: &Selector) -
             .iter()
             .all(|p| request.uri().path().starts_with(p.path()))
         && selector.method.iter().all(|m| request.method() == m)
-        && selector.headers.iter().all(|fields| {
+        && selector.request_headers.iter().all(|fields| {
             fields
                 .iter()
                 .all(|(header, value)| request.headers().get_all(header).iter().any(|f| f == value))
@@ -85,7 +85,7 @@ pub fn select_response(
             .all(|p| uri.path().starts_with(p.path()))
         && selector.method.iter().all(|m| method == m)
         && selector.code.iter().all(|code| response.status() == *code)
-        && selector.headers.iter().all(|fields| {
+        && selector.request_headers.iter().all(|fields| {
             fields
                 .iter()
                 .all(|(header, value)| request_headers.get_all(header).iter().any(|f| f == value))

--- a/src/tproxy.rs
+++ b/src/tproxy.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::matches;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -15,7 +16,7 @@ use tokio::net::TcpStream;
 use tracing::{debug, error, instrument};
 
 use crate::handler::{
-    apply_request_action, apply_response_action, select_request, select_response,
+    apply_request_action, apply_response_action, select_request, select_response, Target,
 };
 
 pub mod config;
@@ -56,15 +57,12 @@ impl HttpService {
     }
 
     async fn handle(self, mut request: Request<Body>) -> Result<Response<Body>> {
-        if let Some(rule) = self
-            .config
-            .rules
-            .request
-            .iter()
-            .find(|rule| select_request(self.target.port(), &request, &rule.selector))
-        {
+        if let Some(rule) = self.config.rules.iter().find(|rule| {
+            matches!(rule.target, Target::Request)
+                && select_request(self.target.port(), &request, &rule.selector)
+        }) {
             debug!("request matched");
-            request = apply_request_action(request, &rule.action).await?;
+            request = apply_request_action(request, &rule.actions).await?;
         }
 
         let uri = request.uri().clone();
@@ -88,18 +86,19 @@ impl HttpService {
             }
         };
 
-        if let Some(rule) = self.config.rules.response.iter().find(|rule| {
-            select_response(
-                self.target.port(),
-                &uri,
-                &method,
-                &headers,
-                &response,
-                &rule.selector,
-            )
+        if let Some(rule) = self.config.rules.iter().find(|rule| {
+            matches!(rule.target, Target::Response)
+                && select_response(
+                    self.target.port(),
+                    &uri,
+                    &method,
+                    &headers,
+                    &response,
+                    &rule.selector,
+                )
         }) {
             debug!("response matched");
-            response = apply_response_action(response, &rule.action).await?;
+            response = apply_response_action(response, &rule.actions).await?;
         }
         Ok(response)
     }

--- a/src/tproxy/config.rs
+++ b/src/tproxy/config.rs
@@ -1,4 +1,4 @@
-use crate::handler::Rules;
+use crate::handler::Rule;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -7,5 +7,5 @@ pub struct Config {
     pub proxy_mark: i32,
     pub ignore_mark: i32,
     pub route_table: u8,
-    pub rules: Rules,
+    pub rules: Vec<Rule>,
 }


### PR DESCRIPTION
Signed-off-by: hexilee <i@hexilee.me>

Currently, the encoded action is not suitable to interact with chaos-daemon. The json-encoded `Action::Abort` is `"abort"` while `Action::Delay(1s)` will be encoded into `{ "delay": "1s" }`.

So this PR merges all actions into one struct.
