### PR TITLE
Add Client Server role option

### DIFF
--- a/chaos-tproxy-controller/src/proxy/config.rs
+++ b/chaos-tproxy-controller/src/proxy/config.rs
@@ -111,7 +111,6 @@ mod tests {
                     proxy_ports: None,
                     listen_port: get_free_port(None).unwrap(),
                     safe_mode: false,
-                    interface: None,
                     rules: vec![],
                     role: None,
                     tls: None
@@ -141,7 +140,6 @@ mod tests {
                     proxy_ports: Some("1025,1026".parse().unwrap()),
                     listen_port: 1027u16,
                     safe_mode: true,
-                    interface: None,
                     rules: vec![],
                     role: None,
                     tls: None

--- a/chaos-tproxy-controller/src/proxy/config.rs
+++ b/chaos-tproxy-controller/src/proxy/config.rs
@@ -45,8 +45,8 @@ impl TryFrom<RawConfig> for Config {
                 rules: raw.rules.map_or(vec![], |rules| rules),
                 role: raw.role.and_then(|role| {
                     Option::from(match role {
-                        RawRole::Client => Role::Client(ipv4s[0]),
-                        RawRole::Server => Role::Server(ipv4s[0]),
+                        RawRole::Client => Role::Client(ipv4s),
+                        RawRole::Server => Role::Server(ipv4s),
                     })
                 }),
             },

--- a/chaos-tproxy-controller/src/proxy/config.rs
+++ b/chaos-tproxy-controller/src/proxy/config.rs
@@ -1,9 +1,12 @@
 use std::convert::TryFrom;
+use std::net::Ipv4Addr;
 
 use anyhow::{anyhow, Error};
-use chaos_tproxy_proxy::raw_config::RawConfig as ProxyRawConfig;
+use chaos_tproxy_proxy::raw_config::{RawConfig as ProxyRawConfig, Role};
+use pnet::ipnetwork::IpNetwork;
 
-use crate::raw_config::RawConfig;
+use crate::proxy::net::bridge::get_default_interface;
+use crate::raw_config::{RawConfig, RawRole};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Config {
@@ -14,6 +17,18 @@ impl TryFrom<RawConfig> for Config {
     type Error = Error;
 
     fn try_from(raw: RawConfig) -> Result<Self, Self::Error> {
+        let ipv4s: Vec<Ipv4Addr> = get_default_interface()?
+            .ips
+            .iter()
+            .filter_map(|ips| match ips {
+                IpNetwork::V4(ipv4) => Some(ipv4),
+                _ => None,
+            })
+            .map(|ipv4| ipv4.ip())
+            .collect();
+        if ipv4s.is_empty() {
+            return Err(anyhow!("no default ipv4"));
+        }
         Ok(Config {
             proxy_config: ProxyRawConfig {
                 proxy_ports: raw.proxy_ports.clone().map(|c| {
@@ -26,12 +41,14 @@ impl TryFrom<RawConfig> for Config {
                     Some(b) => *b,
                     None => false,
                 },
-                interface: raw.interface,
                 listen_port: get_free_port(raw.proxy_ports.clone())?,
-                rules: match raw.rules {
-                    Some(rules) => rules,
-                    None => vec![],
-                },
+                rules: raw.rules.map_or(vec![], |rules| rules),
+                role: raw.role.and_then(|role| {
+                    Option::from(match role {
+                        RawRole::Client => Role::Client(ipv4s[0]),
+                        RawRole::Server => Role::Server(ipv4s[0]),
+                    })
+                }),
             },
         })
     }
@@ -74,9 +91,10 @@ mod tests {
         let config: Config = RawConfig {
             proxy_ports: None,
             safe_mode: None,
-            interface: None,
             rules: None,
 
+            role: None,
+            interface: None,
             listen_port: None,
             proxy_mark: None,
             ignore_mark: None,
@@ -91,8 +109,8 @@ mod tests {
                     proxy_ports: None,
                     listen_port: get_free_port(None).unwrap(),
                     safe_mode: false,
-                    interface: None,
-                    rules: vec![]
+                    rules: vec![],
+                    role: None
                 }
             }
         );
@@ -100,9 +118,10 @@ mod tests {
         let config: Config = RawConfig {
             proxy_ports: Some(vec![1025u16, 1026u16]),
             safe_mode: Some(true),
-            interface: Some("ens33".parse().unwrap()),
             rules: None,
 
+            role: None,
+            interface: None,
             listen_port: None,
             proxy_mark: None,
             ignore_mark: None,
@@ -117,8 +136,8 @@ mod tests {
                     proxy_ports: Some("1025,1026".parse().unwrap()),
                     listen_port: 1027u16,
                     safe_mode: true,
-                    interface: Some("ens33".parse().unwrap()),
-                    rules: vec![]
+                    rules: vec![],
+                    role: None
                 }
             }
         );

--- a/chaos-tproxy-controller/src/proxy/exec.rs
+++ b/chaos-tproxy-controller/src/proxy/exec.rs
@@ -77,12 +77,6 @@ impl Proxy {
         };
 
         tracing::info!(target: "Network device name", "{}", self.net_env.device.clone());
-        match config.interface {
-            None => {}
-            Some(interface) => {
-                self.net_env.set_ip_with_interface_name(&interface)?;
-            }
-        }
         set_net(
             &self.net_env,
             config.proxy_ports,

--- a/chaos-tproxy-controller/src/proxy/net/bridge.rs
+++ b/chaos-tproxy-controller/src/proxy/net/bridge.rs
@@ -71,17 +71,6 @@ impl NetEnv {
         }
     }
 
-    pub fn set_ip_with_interface_name(&mut self, interface: &str) -> anyhow::Result<()> {
-        for i in pnet::datalink::interfaces() {
-            if i.name == interface {
-                self.device = i.name.clone();
-                self.ip = get_ipv4(&i).unwrap();
-                return Ok(());
-            }
-        }
-        return Err(anyhow!("interface : {} not found", interface));
-    }
-
     pub async fn setenv_bridge(&self, handle: &mut Handle) -> Result<()> {
         let Gateway {
             mac_addr: gateway_mac,

--- a/chaos-tproxy-controller/src/proxy/net/bridge.rs
+++ b/chaos-tproxy-controller/src/proxy/net/bridge.rs
@@ -71,17 +71,6 @@ impl NetEnv {
         }
     }
 
-    pub fn set_ip_with_interface_name(&mut self, interface: &str) -> anyhow::Result<()> {
-        for i in pnet::datalink::interfaces() {
-            if i.name == interface {
-                self.device = i.name.clone();
-                self.ip = get_ipv4(&i).unwrap();
-                return Ok(());
-            }
-        }
-        Err(anyhow!("interface : {} not found", interface))
-    }
-
     pub async fn setenv_bridge(&self, handle: &mut Handle) -> Result<()> {
         let Gateway {
             mac_addr: gateway_mac,

--- a/chaos-tproxy-controller/src/raw_config.rs
+++ b/chaos-tproxy-controller/src/raw_config.rs
@@ -6,12 +6,21 @@ use serde::{Deserialize, Serialize};
 pub struct RawConfig {
     pub proxy_ports: Option<Vec<u16>>,
     pub safe_mode: Option<bool>,
-    pub interface: Option<String>,
     pub rules: Option<Vec<RawRule>>,
+    pub role: Option<RawRole>,
+
+    // Useless options now. TODO: complete them
+    pub interface: Option<String>,
 
     // Useless options now. Keep these options for upward compatible.
     pub listen_port: Option<u16>,
     pub proxy_mark: Option<i32>,
     pub ignore_mark: Option<i32>,
     pub route_table: Option<u8>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub enum RawRole {
+    Client,
+    Server,
 }

--- a/chaos-tproxy-controller/src/raw_config.rs
+++ b/chaos-tproxy-controller/src/raw_config.rs
@@ -6,13 +6,21 @@ use serde::{Deserialize, Serialize};
 pub struct RawConfig {
     pub proxy_ports: Option<Vec<u16>>,
     pub safe_mode: Option<bool>,
-    pub interface: Option<String>,
     pub rules: Option<Vec<RawRule>>,
     pub tls: Option<TLSRawConfig>,
+    pub role: Option<RawRole>,
 
+    // Useless options now. TODO: complete them
+    pub interface: Option<String>,
     // Useless options now. Keep these options for upward compatible.
     pub listen_port: Option<u16>,
     pub proxy_mark: Option<i32>,
     pub ignore_mark: Option<i32>,
     pub route_table: Option<u8>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub enum RawRole {
+    Client,
+    Server,
 }

--- a/chaos-tproxy-proxy/src/handler/http/selector.rs
+++ b/chaos-tproxy-proxy/src/handler/http/selector.rs
@@ -19,8 +19,8 @@ pub struct Selector {
 
 pub fn select_role(src_ip: &Ipv4Addr, dst_ip: &Ipv4Addr, role: &Role) -> bool {
     match role {
-        Role::Client(ipv4) => ipv4 == src_ip,
-        Role::Server(ipv4) => ipv4 == dst_ip,
+        Role::Client(ipv4s) => ipv4s.iter().any(|ipv4| ipv4 == src_ip),
+        Role::Server(ipv4s) => ipv4s.iter().any(|ipv4| ipv4 == dst_ip),
     }
 }
 

--- a/chaos-tproxy-proxy/src/handler/http/selector.rs
+++ b/chaos-tproxy-proxy/src/handler/http/selector.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 use http::header::HeaderMap;
 use http::{Method, Request, Response, StatusCode, Uri};
@@ -17,10 +17,19 @@ pub struct Selector {
     pub response_headers: Option<HeaderMap>,
 }
 
-pub fn select_role(src_ip: &Ipv4Addr, dst_ip: &Ipv4Addr, role: &Role) -> bool {
+pub fn select_role(src_ip: &IpAddr, dst_ip: &IpAddr, role: &Role) -> bool {
+    let src_ipv4 = match src_ip {
+        IpAddr::V4(ipv4) => ipv4,
+        _ => return false,
+    };
+    let dst_ipv4 = match dst_ip {
+        IpAddr::V4(ipv4) => ipv4,
+        _ => return false,
+    };
+
     match role {
-        Role::Client(ipv4s) => ipv4s.iter().any(|ipv4| ipv4 == src_ip),
-        Role::Server(ipv4s) => ipv4s.iter().any(|ipv4| ipv4 == dst_ip),
+        Role::Client(ipv4s) => ipv4s.iter().any(|ipv4| ipv4 == src_ipv4),
+        Role::Server(ipv4s) => ipv4s.iter().any(|ipv4| ipv4 == dst_ipv4),
     }
 }
 

--- a/chaos-tproxy-proxy/src/handler/http/selector.rs
+++ b/chaos-tproxy-proxy/src/handler/http/selector.rs
@@ -1,7 +1,11 @@
+use std::net::Ipv4Addr;
+
 use http::header::HeaderMap;
 use http::{Method, Request, Response, StatusCode, Uri};
 use hyper::Body;
 use wildmatch::WildMatch;
+
+use crate::raw_config::Role;
 
 #[derive(Debug, Clone)]
 pub struct Selector {
@@ -11,6 +15,13 @@ pub struct Selector {
     pub code: Option<StatusCode>,
     pub request_headers: Option<HeaderMap>,
     pub response_headers: Option<HeaderMap>,
+}
+
+pub fn select_role(src_ip: &Ipv4Addr, dst_ip: &Ipv4Addr, role: &Role) -> bool {
+    match role {
+        Role::Client(ipv4) => ipv4 == src_ip,
+        Role::Server(ipv4) => ipv4 == dst_ip,
+    }
 }
 
 pub fn select_request(port: u16, request: &Request<Body>, selector: &Selector) -> bool {

--- a/chaos-tproxy-proxy/src/proxy/http/config.rs
+++ b/chaos-tproxy-proxy/src/proxy/http/config.rs
@@ -1,7 +1,9 @@
 use crate::handler::http::rule::Rule;
+use crate::raw_config::Role;
 
 #[derive(Debug, Clone)]
 pub struct Config {
     pub proxy_port: u16,
     pub rules: Vec<Rule>,
+    pub role: Option<Role>,
 }

--- a/chaos-tproxy-proxy/src/proxy/http/server.rs
+++ b/chaos-tproxy-proxy/src/proxy/http/server.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
 use std::future::Future;
 use std::matches;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -24,7 +24,7 @@ use tracing::{debug, error, span, trace, Level};
 
 use crate::handler::http::action::{apply_request_action, apply_response_action};
 use crate::handler::http::rule::Target;
-use crate::handler::http::selector::{select_request, select_response};
+use crate::handler::http::selector::{select_request, select_response, select_role};
 use crate::proxy::http::config::{Config, HTTPConfig};
 use crate::proxy::http::connector::HttpConnector;
 use crate::proxy::tcp::listener::TcpListener;
@@ -203,15 +203,34 @@ impl HttpService {
         }
     }
 
+    fn role_ok(&self) -> bool {
+        let role = match &self.config.role {
+            None => return true,
+            Some(r) => r.clone(),
+        };
+        let remote_v4 = match self.remote.ip() {
+            IpAddr::V4(ipv4) => ipv4,
+            _ => return false,
+        };
+        let target_v4 = match self.target.ip() {
+            IpAddr::V4(ipv4) => ipv4,
+            _ => return false,
+        };
+
+        select_role(&remote_v4, &target_v4, &role)
+    }
+
     async fn handle(self, mut request: Request<Body>) -> Result<Response<Body>> {
         let log_key = format!("{{remote = {}, target = {} }}", self.remote, self.target);
         debug!("{} : Proxy is handling http request", log_key);
+
+        let role_ok = self.role_ok();
         let request_rules: Vec<_> = self
             .config
             .rules
             .iter()
             .filter(|rule| {
-                matches!(rule.target, Target::Request)
+                role_ok && matches!(rule.target, Target::Request)
                     && select_request(self.target.port(), &request, &rule.selector)
             })
             .collect();
@@ -280,7 +299,7 @@ impl HttpService {
             .rules
             .iter()
             .filter(|rule| {
-                matches!(rule.target, Target::Response)
+                role_ok && matches!(rule.target, Target::Response)
                     && select_response(
                         self.target.port(),
                         &uri,

--- a/chaos-tproxy-proxy/src/proxy/http/server.rs
+++ b/chaos-tproxy-proxy/src/proxy/http/server.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
 use std::future::Future;
 use std::matches;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -208,16 +208,8 @@ impl HttpService {
             None => return true,
             Some(r) => r.clone(),
         };
-        let remote_v4 = match self.remote.ip() {
-            IpAddr::V4(ipv4) => ipv4,
-            _ => return false,
-        };
-        let target_v4 = match self.target.ip() {
-            IpAddr::V4(ipv4) => ipv4,
-            _ => return false,
-        };
 
-        select_role(&remote_v4, &target_v4, &role)
+        select_role(&self.remote.ip(), &self.target.ip(), &role)
     }
 
     async fn handle(self, mut request: Request<Body>) -> Result<Response<Body>> {

--- a/chaos-tproxy-proxy/src/proxy/http/server.rs
+++ b/chaos-tproxy-proxy/src/proxy/http/server.rs
@@ -144,7 +144,7 @@ impl HttpService {
             IpAddr::V4(ipv4) => ipv4,
             _ => return false,
         };
-        let target_v4 = match self.remote.ip() {
+        let target_v4 = match self.target.ip() {
             IpAddr::V4(ipv4) => ipv4,
             _ => return false,
         };

--- a/chaos-tproxy-proxy/src/raw_config.rs
+++ b/chaos-tproxy-proxy/src/raw_config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
+use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use anyhow::{anyhow, Error};
@@ -21,8 +22,14 @@ pub struct RawConfig {
     pub proxy_ports: Option<String>,
     pub listen_port: u16,
     pub safe_mode: bool,
-    pub interface: Option<String>,
     pub rules: Vec<RawRule>,
+    pub role: Option<Role>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub enum Role {
+    Client(Ipv4Addr),
+    Server(Ipv4Addr),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
@@ -157,6 +164,7 @@ impl TryFrom<RawConfig> for Config {
                 .into_iter()
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<_>, Self::Error>>()?,
+            role: raw.role,
         })
     }
 }

--- a/chaos-tproxy-proxy/src/raw_config.rs
+++ b/chaos-tproxy-proxy/src/raw_config.rs
@@ -28,8 +28,8 @@ pub struct RawConfig {
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub enum Role {
-    Client(Ipv4Addr),
-    Server(Ipv4Addr),
+    Client(Vec<Ipv4Addr>),
+    Server(Vec<Ipv4Addr>),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]

--- a/chaos-tproxy-proxy/src/raw_config.rs
+++ b/chaos-tproxy-proxy/src/raw_config.rs
@@ -3,6 +3,7 @@ use std::convert::{TryFrom, TryInto};
 use std::path::PathBuf;
 use std::time::Duration;
 use std::{fs, io};
+use std::net::Ipv4Addr;
 
 use anyhow::{anyhow, Error};
 use http::header::{HeaderMap, HeaderName};
@@ -29,7 +30,14 @@ pub struct RawConfig {
     pub safe_mode: bool,
     pub interface: Option<String>,
     pub rules: Vec<RawRule>,
+    pub role: Option<Role>,
     pub tls: Option<TLSRawConfig>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub enum Role {
+    Client(Vec<Ipv4Addr>),
+    Server(Vec<Ipv4Addr>),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
@@ -191,6 +199,7 @@ impl TryFrom<RawConfig> for Config {
         Ok(Self {
             http_config: HTTPConfig {
                 proxy_port: raw.listen_port,
+                role: raw.role,
                 rules: raw
                     .rules
                     .into_iter()

--- a/chaos-tproxy-proxy/src/raw_config.rs
+++ b/chaos-tproxy-proxy/src/raw_config.rs
@@ -28,7 +28,6 @@ pub struct RawConfig {
     pub proxy_ports: Option<String>,
     pub listen_port: u16,
     pub safe_mode: bool,
-    pub interface: Option<String>,
     pub rules: Vec<RawRule>,
     pub role: Option<Role>,
     pub tls: Option<TLSRawConfig>,

--- a/tests/integrations/test_http_action.rs
+++ b/tests/integrations/test_http_action.rs
@@ -1,7 +1,7 @@
+use chaos_tproxy_proxy::handler::http::action::{apply_request_action, Actions, ReplaceAction};
 use http::header::CONTENT_LENGTH;
 use http::HeaderMap;
 use hyper::{Body, Client, Method, Request};
-use chaos_tproxy_proxy::handler::http::action::{apply_request_action, Actions, ReplaceAction};
 
 #[tokio::test]
 #[ignore]


### PR DESCRIPTION
 Add a Client-Server role option.
When user set Client role in config, action will just apply when HTTP-TCP-source-IP == default IP.
When user set Server role in config, action will just apply when HTTP-TCP-dst-IP == default IP.

I also delete some interface option in proxy just because I find this option not really works & brings some BUGs. 
related issue: #46 