### PR TITLE
chore: rename ambigous field proxy_port -> listen_port

### DIFF
--- a/chaos-tproxy-proxy/src/proxy/http/config.rs
+++ b/chaos-tproxy-proxy/src/proxy/http/config.rs
@@ -11,7 +11,7 @@ pub struct Config {
 
 #[derive(Clone, Debug)]
 pub struct HTTPConfig {
-    pub proxy_port: u16,
+    pub listen_port: u16,
     pub rules: Vec<Rule>,
     pub role: Option<Role>,
 }

--- a/chaos-tproxy-proxy/src/proxy/http/server.rs
+++ b/chaos-tproxy-proxy/src/proxy/http/server.rs
@@ -40,7 +40,7 @@ impl HttpServer {
     }
 
     pub async fn serve(&mut self, mut rx: Receiver<()>) -> Result<()> {
-        let addr = SocketAddr::from(([0, 0, 0, 0], self.config.http_config.proxy_port));
+        let addr = SocketAddr::from(([0, 0, 0, 0], self.config.http_config.listen_port));
         let listener = TcpListener::bind(addr)?;
         tracing::info!("Proxy Listening");
         let http_config = Arc::new(self.config.http_config.clone());
@@ -222,7 +222,8 @@ impl HttpService {
             .rules
             .iter()
             .filter(|rule| {
-                role_ok && matches!(rule.target, Target::Request)
+                role_ok
+                    && matches!(rule.target, Target::Request)
                     && select_request(self.target.port(), &request, &rule.selector)
             })
             .collect();
@@ -291,7 +292,8 @@ impl HttpService {
             .rules
             .iter()
             .filter(|rule| {
-                role_ok && matches!(rule.target, Target::Response)
+                role_ok
+                    && matches!(rule.target, Target::Response)
                     && select_response(
                         self.target.port(),
                         &uri,

--- a/chaos-tproxy-proxy/src/raw_config.rs
+++ b/chaos-tproxy-proxy/src/raw_config.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
+use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::{fs, io};
-use std::net::Ipv4Addr;
 
 use anyhow::{anyhow, Error};
 use http::header::{HeaderMap, HeaderName};
@@ -197,7 +197,7 @@ impl TryFrom<RawConfig> for Config {
     fn try_from(raw: RawConfig) -> Result<Self, Self::Error> {
         Ok(Self {
             http_config: HTTPConfig {
-                proxy_port: raw.listen_port,
+                listen_port: raw.listen_port,
                 role: raw.role,
                 rules: raw
                     .rules


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

here are other fields with similar name("proxy_ports") in

- https://github.com/STRRL/chaos-tproxy/blob/7845fee9c14c9395d3e87205c44874d6fddf379d/chaos-tproxy-proxy/src/raw_config.rs#L28
- https://github.com/STRRL/chaos-tproxy/blob/7845fee9c14c9395d3e87205c44874d6fddf379d/chaos-tproxy-controller/src/raw_config.rs#L7

And `chaos_tproxy_proxy::proxy::http::server::HttpServer` does not consider about them at all.

Rename it as `listen_port` would reduce the misunderstanding 