### PR TITLE
fix: use base64 to deserialize RawFile.Contents

### DIFF
--- a/chaos-tproxy-proxy/src/raw_config.rs
+++ b/chaos-tproxy-proxy/src/raw_config.rs
@@ -43,7 +43,23 @@ pub enum Role {
 #[serde(tag = "type", content = "value")]
 pub enum RawFile {
     Path(PathBuf),
+    #[serde(with="contents_base64")]
     Contents(Vec<u8>),
+}
+mod contents_base64 {
+    use serde::{Serialize, Deserialize};
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
+        let base64 = base64::encode(v);
+        String::serialize(&base64, s)
+    }
+    
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let base64 = String::deserialize(d)?;
+        base64::decode(base64.as_bytes())
+            .map_err(|e| serde::de::Error::custom(e))
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize, Default)]


### PR DESCRIPTION
fix https://github.com/chaos-mesh/chaos-tproxy/issues/63

