### PR TITLE
fix:unneeded `return` statement

### DIFF
--- a/chaos-tproxy-proxy/src/uds_client.rs
+++ b/chaos-tproxy-proxy/src/uds_client.rs
@@ -28,7 +28,7 @@ impl UdsDataClient {
     ) -> anyhow::Result<T> {
         tracing::debug!("try connect path : {:?}", &self.path);
         let mut stream = UnixStream::connect(self.path.clone()).await?;
-        return match stream.read_to_end(buf).await {
+        match stream.read_to_end(buf).await {
             Ok(_) => {
                 tracing::debug!("Read data successfully.");
 
@@ -47,6 +47,6 @@ impl UdsDataClient {
                 tracing::debug!("Read data failed with err {:?}.", e);
                 Err(anyhow::anyhow!("{}", e))
             }
-        };
+        }
     }
 }


### PR DESCRIPTION
error: unneeded `return` statement
```
  --> chaos-tproxy-proxy/src/uds_client.rs:31:9
   |
31 | /         return match stream.read_to_end(buf).await {
32 | |             Ok(_) => {
33 | |                 tracing::debug!("Read data successfully.");
...  |
50 | |         };
   | |_________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
   = note: `-D clippy::needless-return` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_return)]`
help: remove `return`
   |
31 ~         match stream.read_to_end(buf).await {
32 +             Ok(_) => {
33 +                 tracing::debug!("Read data successfully.");
34 + 
35 +                 match serde_json::from_slice(buf.as_slice()) {
36 +                     Ok(o) => {
37 +                         tracing::debug!("Deserialize data successfully.");
38 +                         Ok(o)
39 +                     }
40 +                     Err(e) => {
41 +                         tracing::debug!("Deserialize data failed.");
42 +                         Err(anyhow::anyhow!("{}", e))
43 +                     }
44 +                 }
45 +             }
46 +             Err(e) => {
47 +                 tracing::debug!("Read data failed with err {:?}.", e);
48 +                 Err(anyhow::anyhow!("{}", e))
49 +             }
50 ~         }
   |
```
error: could not compile `chaos-tproxy-proxy` (lib) due to 1 previous error